### PR TITLE
small Chars changes

### DIFF
--- a/protobuf/src/chars.rs
+++ b/protobuf/src/chars.rs
@@ -23,6 +23,16 @@ impl Chars {
         self.0.clear();
     }
 
+    /// Create from a static string.
+    pub fn from_static_str(src: &'static str) -> Chars {
+        Chars(Bytes::from_static(src.as_bytes()))
+    }
+
+    /// Create from a string reference.
+    pub fn from_ref_str(src: &str) -> Chars {
+        Chars(Bytes::copy_from_slice(src.as_bytes()))
+    }
+
     /// Try convert from `Bytes`
     pub fn from_bytes(bytes: Bytes) -> Result<Chars, str::Utf8Error> {
         str::from_utf8(&bytes)?;
@@ -39,11 +49,10 @@ impl Chars {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
-}
 
-impl<'a> From<&'a str> for Chars {
-    fn from(src: &'a str) -> Chars {
-        Chars(Bytes::copy_from_slice(src.as_bytes()))
+    /// Consume self and return the underlying bytes.
+    pub fn into_bytes(self) -> Bytes {
+        self.0
     }
 }
 
@@ -104,7 +113,7 @@ mod test {
     fn test_display_and_debug() {
         let s = "test";
         let string: String = s.into();
-        let chars: Chars = s.into();
+        let chars: Chars = Chars::from_static_str(s);
 
         assert_eq!(format!("{}", string), format!("{}", chars));
         assert_eq!(format!("{:?}", string), format!("{:?}", chars));


### PR DESCRIPTION
Allow extraction of the underlying Bytes and allow zero copy construction from static string references.