### PR TITLE
make oneofs exhausted

### DIFF
--- a/protobuf-codegen/src/gen/oneof.rs
+++ b/protobuf-codegen/src/gen/oneof.rs
@@ -252,7 +252,6 @@ impl<'a> OneofGen<'a> {
     fn write_enum(&self, w: &mut CodeWriter) {
         let derive = vec!["Clone", "PartialEq", "Debug"];
         w.derive(&derive);
-        w.write_line("#[non_exhaustive]");
         write_protoc_insertion_point_for_oneof(w, &self.customize.for_elem, &self.oneof.oneof);
         w.pub_enum(&self.oneof.rust_name().ident.to_string(), |w| {
             for variant in self.variants_except_group() {


### PR DESCRIPTION
We control our own code and this makes compile errors more obvious.