### PR TITLE
protobuf-json-mapping: add field_filter to PrintOptions

### DIFF
--- a/protobuf-json-mapping/src/print.rs
+++ b/protobuf-json-mapping/src/print.rs
@@ -1,8 +1,10 @@
 use std::fmt;
 use std::fmt::Write as fmt_Write;
+use std::sync::Arc;
 
 use protobuf::reflect::EnumDescriptor;
 use protobuf::reflect::EnumValueDescriptor;
+use protobuf::reflect::FieldDescriptor;
 use protobuf::reflect::MessageRef;
 use protobuf::reflect::ReflectFieldRef;
 use protobuf::reflect::ReflectMapRef;
@@ -481,6 +483,13 @@ impl Printer {
         write!(self.buf, "{{")?;
         let mut first = true;
         for field in descriptor.fields() {
+            // When a field filter is set, skip fields that the caller wants excluded.
+            if let Some(ref filter) = self.print_options.field_filter {
+                if !filter(&field) {
+                    continue;
+                }
+            }
+
             let json_field_name = if self.print_options.proto_field_name {
                 field.name()
             } else {
@@ -560,7 +569,6 @@ impl Printer {
 ///     ..Default::default()
 /// };
 /// ```
-#[derive(Default, Debug, Clone)]
 pub struct PrintOptions {
     /// Use ints instead of strings for enums.
     ///
@@ -571,8 +579,51 @@ pub struct PrintOptions {
     pub proto_field_name: bool,
     /// Output field default values.
     pub always_output_default_values: bool,
+    /// Optional per-field filter applied during serialization. When set, only
+    /// fields for which the callback returns `true` are included in the JSON
+    /// output. The filter is consulted recursively for nested messages.
+    pub field_filter: Option<Arc<dyn Fn(&FieldDescriptor) -> bool + Send + Sync>>,
     /// Prevent initializing `PrintOptions` enumerating all field.
     pub _future_options: (),
+}
+
+impl Default for PrintOptions {
+    fn default() -> Self {
+        Self {
+            enum_values_int: false,
+            proto_field_name: false,
+            always_output_default_values: false,
+            field_filter: None,
+            _future_options: (),
+        }
+    }
+}
+
+impl Clone for PrintOptions {
+    fn clone(&self) -> Self {
+        Self {
+            enum_values_int: self.enum_values_int,
+            proto_field_name: self.proto_field_name,
+            always_output_default_values: self.always_output_default_values,
+            field_filter: self.field_filter.clone(),
+            _future_options: (),
+        }
+    }
+}
+
+impl fmt::Debug for PrintOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrintOptions")
+            .field("enum_values_int", &self.enum_values_int)
+            .field("proto_field_name", &self.proto_field_name)
+            .field(
+                "always_output_default_values",
+                &self.always_output_default_values,
+            )
+            .field("field_filter", &self.field_filter.is_some())
+            .field("_future_options", &self._future_options)
+            .finish()
+    }
 }
 
 /// Serialize message to JSON according to protobuf specification.

--- a/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_fmt_json.rs
+++ b/test-crates/protobuf-codegen-protoc-test/src/common/v2/test_fmt_json.rs
@@ -362,3 +362,40 @@ fn test_more_than_one() {
         &m,
     );
 }
+
+#[test]
+fn test_field_filter_excludes_non_matching_fields() {
+    let mut m = TestTypes::new();
+    m.set_bool_singular(true);
+    m.set_string_singular("hello".to_owned());
+    m.set_int32_singular(42);
+
+    // Only include the bool and string fields via filter.
+    let print_options = protobuf_json_mapping::PrintOptions {
+        field_filter: Some(std::sync::Arc::new(|field| {
+            field.name() == "bool_singular" || field.name() == "string_singular"
+        })),
+        ..Default::default()
+    };
+    let json = protobuf_json_mapping::print_to_string_with_options(&m, &print_options).unwrap();
+    assert_eq!(
+        "{\"boolSingular\": true, \"stringSingular\": \"hello\"}",
+        json
+    );
+}
+
+#[test]
+fn test_field_filter_with_always_output_defaults() {
+    let m = TestIncludeDefaultValues::new();
+
+    // With field_filter + always_output_default_values, the filter controls which
+    // default-valued fields are emitted. iii is a plain optional int32 so its
+    // default (0) should appear when both flags are set.
+    let print_options = protobuf_json_mapping::PrintOptions {
+        always_output_default_values: true,
+        field_filter: Some(std::sync::Arc::new(|field| field.name() == "iii")),
+        ..Default::default()
+    };
+    let json = protobuf_json_mapping::print_to_string_with_options(&m, &print_options).unwrap();
+    assert_eq!("{\"iii\": 0}", json);
+}


### PR DESCRIPTION
## Summary

Add an optional per-field filter callback to `PrintOptions`. When set, only fields for which the filter returns `true` are included in the JSON output. The filter is consulted recursively for nested messages via `print_regular_message`.

This enables callers to selectively hide fields during JSON serialization without mutating the source message, which is useful when combined with `always_output_default_values` to emit all allowed fields (including defaults) while excluding others.

## Changes

- Add `field_filter: Option<Arc<dyn Fn(&FieldDescriptor) -> bool + Send + Sync>>` to `PrintOptions`
- Replace `#[derive(Default, Debug, Clone)]` with manual impls (required because `Arc<dyn Fn>` does not impl `Debug`)
- Check the filter at the top of the `print_regular_message` field loop
- Add two test cases covering basic filtering and interaction with `always_output_default_values`